### PR TITLE
Add macOS Sequoia stub build

### DIFF
--- a/BG3Extender/GameDefinitions/Net.h
+++ b/BG3Extender/GameDefinitions/Net.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#ifdef _WIN32
 #include <windows.h>
+#elif defined(__APPLE__)
+#include <CoreFoundation/CoreFoundation.h>
+#endif
 #include <GameDefinitions/Base/Base.h>
 #include <GameDefinitions/Enumerations.h>
 // Temporarily, for ComponentCallbakcList

--- a/BG3Extender/stdafx.h
+++ b/BG3Extender/stdafx.h
@@ -2,12 +2,21 @@
 
 #include "targetver.h"
 
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 #define NOMINMAX
 
-// Windows Header Files:
+// Windows Header Files
 #include <windows.h>
 #include <detours.h>
+#elif defined(__APPLE__)
+// macOS specific includes
+#include <TargetConditionals.h>
+// Detours is Windows only; placeholder for macOS hooking library if needed
+#define DETOURS_STUB 1
+#else
+#error "Unsupported platform"
+#endif
 
 #include <memory>
 #include <cstdint>

--- a/BG3Extender/targetver.h
+++ b/BG3Extender/targetver.h
@@ -5,6 +5,13 @@
 // If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
 // set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
 
+#ifdef _WIN32
 #define _WIN32_WINNT _WIN32_WINNT_WIN8
-
 #include <SDKDDKVer.h>
+#elif defined(__APPLE__)
+// Target macOS Sequoia 15.5
+#include <AvailabilityMacros.h>
+#define MACOSX_DEPLOYMENT_TARGET "15.5"
+#else
+#error "Unsupported platform"
+#endif

--- a/BG3Updater/stdafx.h
+++ b/BG3Updater/stdafx.h
@@ -7,10 +7,13 @@
 
 #include "targetver.h"
 
+#ifdef _WIN32
 #define NOMINMAX
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
-// Windows Header Files
 #include <windows.h>
+#elif defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
 
 #include <string>
 #include <memory>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.16)
+project(bg3se_stub)
+
+if(APPLE)
+    add_library(bg3se_stub SHARED macos/bg3se_stub.cpp)
+    set_target_properties(bg3se_stub PROPERTIES
+        OUTPUT_NAME bg3se
+        MACOSX_RPATH ON
+    )
+else()
+    message(FATAL_ERROR "This CMake setup only supports macOS")
+endif()

--- a/CoreLib/stdafx.h
+++ b/CoreLib/stdafx.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 #define NOMINMAX
-
 #include <windows.h>
+#elif defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
 
 #include <memory>
 #include <cstdint>

--- a/CrashReporter/stdafx.h
+++ b/CrashReporter/stdafx.h
@@ -7,9 +7,12 @@
 
 #include "targetver.h"
 
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
-// Windows Header Files
 #include <windows.h>
+#elif defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
 
 #include <string>
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@
 The Script Extender adds Lua/Osiris scripting support to the game.
 [API Documentation](https://github.com/Norbyte/bg3se/blob/master/Docs/API.md)
 
+### macOS Sequoia 15.5 Support
+
+Experimental support for macOS is provided via a minimal stub library. To build
+the stub on macOS 15.5 or newer run the following commands:
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+```
+
+This will produce `libbg3se.dylib`, which currently only prints a message at
+runtime indicating that the full Script Extender functionality is not available
+yet on macOS.
+
 ### Configuration
 
 The following configuration variables can be set in the `ScriptExtenderSettings.json` file:

--- a/macos/bg3se_stub.cpp
+++ b/macos/bg3se_stub.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+extern "C" int bg3se_stub()
+{
+    std::cerr << "BG3 Script Extender is not yet supported on macOS Sequoia 15.5" << std::endl;
+    return -1;
+}


### PR DESCRIPTION
## Summary
- add macOS stub CMake build for Sequoia 15.5
- include macOS headers conditionally
- document macOS support and build instructions

## Testing
- `cmake ..` *(fails: This CMake setup only supports macOS)*

------
https://chatgpt.com/codex/tasks/task_e_6850d5f97cb08325a2a512aed763be69