### PR TITLE
Add simple test GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,20 @@ The following configuration variables can be set in the `ScriptExtenderSettings.
 ### Build Instructions
 
 Download the latest [external dependencies from here](https://nb-stor.s3.eu-central-1.amazonaws.com/bg3-legacy/External.7z) and extract them to the `External/` folder.
+
+### Testing with the GUI
+
+A small Python GUI is provided to make running the diagnostic script easier for end users.
+
+1. Ensure you have Python 3 installed.
+2. Run the GUI from the `TestGUI` folder:
+
+```bash
+python3 test_gui.py
+```
+
+On Windows systems, click **Run Diagnostic** to execute the bundled
+`Generate BG3 Diagnostic.bat` script. The diagnostic report will appear in your
+`%TEMP%` folder as `BG3 Diagnostic Data.txt`.
+
+On non‑Windows systems a message will indicate that the script is not available.

--- a/TestGUI/test_gui.py
+++ b/TestGUI/test_gui.py
@@ -1,0 +1,47 @@
+import os
+import platform
+import subprocess
+import tkinter as tk
+from tkinter import messagebox
+
+
+SCRIPT_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.pardir, "Generate BG3 Diagnostic.bat")
+)
+
+
+def run_diagnostic():
+    if platform.system() != "Windows":
+        messagebox.showinfo(
+            "Unsupported",
+            "Diagnostic script is only available on Windows.",
+        )
+        return
+    if not os.path.exists(SCRIPT_PATH):
+        messagebox.showerror("Error", f"Script not found: {SCRIPT_PATH}")
+        return
+    try:
+        subprocess.run(["cmd", "/c", SCRIPT_PATH], check=True)
+        messagebox.showinfo(
+            "Finished",
+            "Diagnostic completed. Check your TEMP folder for 'BG3 Diagnostic Data.txt'.",
+        )
+    except subprocess.CalledProcessError:
+        messagebox.showerror("Error", "Diagnostic script failed.")
+
+
+def main():
+    root = tk.Tk()
+    root.title("BG3 Extender Test Helper")
+    tk.Label(
+        root,
+        text="Click the button below to run diagnostics for BG3 Extender.",
+        wraplength=300,
+    ).pack(padx=10, pady=10)
+    tk.Button(root, text="Run Diagnostic", command=run_diagnostic).pack(pady=5)
+    tk.Button(root, text="Quit", command=root.quit).pack(pady=5)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a TestGUI directory with a simple tkinter helper
- document how to launch the GUI for diagnostics

## Testing
- `python3 -m py_compile TestGUI/test_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6850d908f04483259b8274aeda206c78