### PR TITLE
Add macOS stub installer script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -347,3 +347,7 @@ TestModule/Mods/BG3Ext_Testsuite/.vscode/settings.json
 BG3Extender/Lua.bundle
 BG3Extender/LuaScripts/.vscode
 BG3Extender/GameDefinitions/Generated
+# macOS stub build artifacts
+build/
+macos/pkgroot/
+bg3se_stub_installer.pkg

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ appear when the game launches, confirming that the injection succeeded.
 The stub does not yet provide Script Extender features but verifies that the
 loading mechanism works on your system.
 
+#### Creating an installer
+
+To simplify distribution a helper script is provided that builds the stub and
+packages it into a standard `.pkg` installer. Running the script will generate
+`bg3se_stub_installer.pkg` in the repository root. When executed, the installer
+copies `libbg3se.dylib` into `Baldur's Gate 3.app/Contents/MacOS/`.
+
+```bash
+macos/create_stub_installer.sh
+open bg3se_stub_installer.pkg
+```
+
+This allows installing the stub without using the terminal beyond launching the
+script.
+
 ### Configuration
 
 The following configuration variables can be set in the `ScriptExtenderSettings.json` file:

--- a/macos/create_stub_installer.sh
+++ b/macos/create_stub_installer.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Build the bg3se stub and generate a .pkg installer for macOS.
+# The installer places libbg3se.dylib into the standard BG3 application folder.
+set -euo pipefail
+
+BUILD_DIR="$(pwd)/build"
+INSTALL_ROOT="$(pwd)/macos/pkgroot"
+PKG_NAME="bg3se_stub_installer.pkg"
+
+rm -rf "$BUILD_DIR" "$INSTALL_ROOT" "$PKG_NAME"
+mkdir -p "$BUILD_DIR" "$INSTALL_ROOT/Applications/Baldur's Gate 3.app/Contents/MacOS"
+
+# Build the stub
+pushd "$BUILD_DIR" >/dev/null
+cmake ..
+make
+popd >/dev/null
+
+# Copy stub into pkg root
+cp "$BUILD_DIR/libbg3se.dylib" "$INSTALL_ROOT/Applications/Baldur's Gate 3.app/Contents/MacOS/"
+
+pkgbuild \
+    --identifier "dev.norbyte.bg3se.stub" \
+    --version "1.0" \
+    --root "$INSTALL_ROOT" \
+    "bg3se_stub_component.pkg"
+
+productbuild \
+    --package "bg3se_stub_component.pkg" \
+    "$PKG_NAME"
+
+rm -f bg3se_stub_component.pkg
+
+cat <<EOM
+Created installer: $PKG_NAME
+This package installs libbg3se.dylib into /Applications/Baldur's Gate 3.app/Contents/MacOS/
+EOM
+


### PR DESCRIPTION
## Summary
- provide a shell script that builds the macOS stub and generates a `.pkg` installer
- mention the helper script in the README
- ignore build and installer artifacts

## Testing
- `cmake ..` *(fails: This CMake setup only supports macOS)*
- `bash macos/create_stub_installer.sh` *(fails: This CMake setup only supports macOS)*

------
https://chatgpt.com/codex/tasks/task_e_6850db460a5c83259fca500ef273815d